### PR TITLE
Update joint.yaml

### DIFF
--- a/data/yaml/joint.yaml
+++ b/data/yaml/joint.yaml
@@ -1,5 +1,5 @@
 acl:
-  2020: [2020.autosimtrans-1, 2020.bionlp-1, 2020.challengehml-1, 2020.fever-1, 2020.nlp4convai-1, 2020.repl4nlp-1, 2020.sigmorphon-1, 2020.soc, alnlp-1, 2020.winlp-1, 2020.alvr-1, 2020.bea-1, 2020.ecnlp-1, 2020.figlang-1, 2020.iwpt-1, 2020.iwslt-1, 2020.nli-1, 2020.nlpmc-1, 2020.nuse-1, 2020.ngt-1]
+  2020: [2020.autosimtrans-1, 2020.bionlp-1, 2020.challengehml-1, 2020.fever-1, 2020.nlp4convai-1, 2020.repl4nlp-1, 2020.sigmorphon-1, 2020.socialnlp-1, 2020.winlp-1, 2020.alvr-1, 2020.bea-1, 2020.ecnlp-1, 2020.figlang-1, 2020.iwpt-1, 2020.iwslt-1, 2020.nli-1, 2020.nlpmc-1, 2020.nuse-1, 2020.ngt-1]
   2012:
   - W12-32
   - W12-33


### PR DESCRIPTION
Updated the split entries "2020.soc" and "alnlp-1" into a single anthology entry representing "2020.socialnlp-1".

This fix has been made while working on the ingestion of ACL 2020 videos referenced in #986. 
